### PR TITLE
Support list in GOPATH

### DIFF
--- a/unused/unused_func_finder.go
+++ b/unused/unused_func_finder.go
@@ -3,8 +3,6 @@
 package unused
 
 import (
-	"code.google.com/p/go.tools/oracle"
-	"code.google.com/p/go.tools/oracle/serial"
 	"encoding/json"
 	"fmt"
 	"go/ast"
@@ -15,6 +13,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/tools/oracle"
+	"golang.org/x/tools/oracle/serial"
 )
 
 //TODO rename to FuncEntry or something

--- a/unused/unused_func_finder.go
+++ b/unused/unused_func_finder.go
@@ -192,14 +192,22 @@ func isDir(filename string) bool {
 
 // helper for grabbing package name from its folder
 func getFullPkgName(filename string) (string, error) {
-	gopath := os.Getenv("GOPATH")
 	abs, err := filepath.Abs(filename)
 	if err != nil {
 		return "", err
 	}
-	//TODO, make this nicer and add a test
-	strippedGopath := strings.TrimPrefix(abs, filepath.Join(gopath, "/src/")+"/")
-	return filepath.Dir(strippedGopath), nil
+	goPaths := filepath.SplitList(os.Getenv("GOPATH"))
+	for _, p := range goPaths {
+		p = filepath.Join(p, "src") + "/"
+		if !strings.HasPrefix(abs, p) {
+			continue
+		}
+		stripped := strings.TrimPrefix(abs, p)
+		return filepath.Dir(stripped), nil
+	}
+	// a check during initialization ensures that GOPATH != "" so this
+	// should be safe
+	return "", fmt.Errorf("cd %q and try again", goPaths[len(goPaths)-1])
 }
 
 func (uff *UnusedFuncFinder) canReadSourceFile(filename string) bool {


### PR DESCRIPTION
This is built atop #2 which is required to build at all.

GOPATH is not a single directory. It is a list in the format of filepath.SplitList. See http://golang.org/pkg/go/build/#hdr-Go_Path.

I suspect the proper solution is a larger change. As a user, I would expect to give go-unused-funcs the same thing I might give to go get. However, this change gets it working for those of us with multiple directories in our GOPATH's.
