### PR TITLE
Add option to exit with error if unused code has been found

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ codecornor -tags debug funcs ./...
 The `-tags` flag lets you pass build tags like you would during a regular `go build`. 
 If your codebase uses flags, note that unbuilt files may show up as dead code.
 
+##### -errorIfFound
+```
+codecornor -errorIfFound funcs ./...
+```
+
+The `-errorIfFound` flag lets you specify that a non-zero exit code should be used if
+dead code is detected. This allows CI and similar systems to flag the fact dead code exists.
+
 #### Troubleshooting
 
 Some notes that may help with troubleshooting:

--- a/main.go
+++ b/main.go
@@ -12,7 +12,11 @@ import (
 )
 
 func main() {
-	var ignoreList string
+	var (
+		ignoreList           string
+		exitWithErrorIfFound bool
+	)
+
 	ucf := unused.NewUnusedCodeFinder()
 	flag.BoolVar(&(ucf.Verbose), "v", false,
 		"prints extra information during execution to stderr")
@@ -21,6 +25,7 @@ func main() {
 		"don't read files that contain the given comma-separated strings (use to avoid /testdata, etc) ")
 	// hack for testing code with build flags
 	flag.Var((*buildutil.TagsFlag)(&build.Default.BuildTags), "tags", "a list of build tags")
+	flag.BoolVar(&exitWithErrorIfFound, "errorIfFound", false, "exit with an error code if unused code is found")
 	flag.Parse()
 	// handle ignore list
 	ucf.Ignore = strings.Split(ignoreList, ",")
@@ -53,5 +58,9 @@ func main() {
 	sort.Sort(unused.ByPosition(unusedObjects))
 	for _, o := range unusedObjects {
 		fmt.Printf("%s\n", o)
+	}
+
+	if exitWithErrorIfFound && len(unusedObjects) > 0 {
+		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
When running in CI, makefiles, etc., returning an error code can be used to signify there is a problem such as the existence of unused code.

This PR adds an option to exit with an error code if unused code is found too allow automated processes to highlight the problem.